### PR TITLE
Log the error messages in exceptions caught

### DIFF
--- a/lambda/copy_snapshots_dest_aurora/lambda_function.py
+++ b/lambda/copy_snapshots_dest_aurora/lambda_function.py
@@ -70,8 +70,9 @@ def lambda_handler(event, context):
                     try:
                         copy_local(shared_identifier, shared_attributes)
 
-                    except Exception:
+                    except Exception as e:
                         pending_copies += 1
+                        logger.error(e)
                         logger.error('Local copy pending: %s' % shared_identifier)
 
                     else:
@@ -92,8 +93,9 @@ def lambda_handler(event, context):
                 try:
                     copy_remote(shared_identifier, own_snapshots[shared_identifier])
                  
-                except Exception:
+                except Exception as e:
                     pending_copies += 1
+                    logger.error(e)
                     logger.error('Remote copy pending: %s: %s' % (
                         shared_identifier, own_snapshots[shared_identifier]['Arn']))
             else:

--- a/lambda/copy_snapshots_no_x_account_aurora/lambda_function.py
+++ b/lambda/copy_snapshots_no_x_account_aurora/lambda_function.py
@@ -69,8 +69,9 @@ def lambda_handler(event, context):
                         try:
                             copy_remote(source_identifier, own_snapshots_encryption[source_identifier])
                  
-                        except Exception:
+                        except Exception as e:
                             pending_copies += 1
+                            logger.error(e)
                             logger.error('Remote copy pending: %s: %s' % (
                                 source_identifier, source_snapshots[source_identifier]['Arn']))
                     else:

--- a/lambda/delete_old_snapshots_aurora/lambda_function.py
+++ b/lambda/delete_old_snapshots_aurora/lambda_function.py
@@ -66,8 +66,9 @@ def lambda_handler(event, context):
                     client.delete_db_cluster_snapshot(
                         DBClusterSnapshotIdentifier=snapshot)
 
-                except Exception:
+                except Exception as e:
                     pending_delete += 1
+                    logger.info(e)
                     logger.info('Could not delete %s ' % snapshot)
 
             else:

--- a/lambda/delete_old_snapshots_dest_aurora/lambda_function.py
+++ b/lambda/delete_old_snapshots_dest_aurora/lambda_function.py
@@ -70,9 +70,10 @@ def lambda_handler(event, context):
                         client.delete_db_cluster_snapshot(
                             DBClusterSnapshotIdentifier=snapshot)
 
-                    except Exception:
+                    except Exception as e:
                         delete_pending += 1
-                        logger.info('Could not delete %s' % snapshot)
+                        logger.error(e)
+                        logger.error('Could not delete %s' % snapshot)
 
                 else:
                     logger.info('Not deleting %s. Only %s days old' %

--- a/lambda/share_snapshots_aurora/lambda_function.py
+++ b/lambda/share_snapshots_aurora/lambda_function.py
@@ -58,8 +58,8 @@ def lambda_handler(event, context):
                         DEST_ACCOUNTID
                     ]
                 )
-            except Exception:
-                logger.error('Exception sharing %s' % snapshot_identifier)
+            except Exception as e:
+                logger.error('Exception sharing {}: {}'.format(snapshot_identifier, e))
                 pending_snapshots += 1
 
     if pending_snapshots > 0:

--- a/lambda/take_snapshots_aurora/lambda_function.py
+++ b/lambda/take_snapshots_aurora/lambda_function.py
@@ -74,7 +74,8 @@ def lambda_handler(event, context):
                     Tags=[{'Key': 'CreatedBy', 'Value': 'Snapshot Tool for Aurora'}, {
                         'Key': 'CreatedOn', 'Value': timestamp_format}, {'Key': 'shareAndCopy', 'Value': 'YES'}]
                 )
-            except Exception:
+            except Exception as e:
+                logger.error(e)
                 pending_backups += 1
         else:
 


### PR DESCRIPTION
It can be quite difficult to determine the cause for backups to fail and go into "pending". Write the error messages to the log to assist in debugging.