### PR TITLE
Add cwAlarm descriptions & more actions

### DIFF
--- a/cftemplates/snapshots_tool_aurora_dest.json
+++ b/cftemplates/snapshots_tool_aurora_dest.json
@@ -161,6 +161,7 @@
 		"alarmcwCopyFailedDest": {
 			"Type": "AWS::CloudWatch::Alarm",
 			"Properties": {
+				"AlarmDescription": "DB Copy to destination status",
 				"ActionsEnabled": "true",
 				"ComparisonOperator": "GreaterThanOrEqualToThreshold",
 				"EvaluationPeriods": "1",
@@ -169,7 +170,22 @@
 				"Period": "300",
 				"Statistic": "Sum",
 				"Threshold": "2.0",
+				"TreatMissingData": "ignore",
 				"AlarmActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraToolDest"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"OKActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraToolDest"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"InsufficientDataActions": [{
 					"Fn::If": ["SNSTopicIsEmpty", {
 						"Ref": "snsTopicSnapshotsAuroraToolDest"
 					}, {
@@ -188,6 +204,7 @@
 			"Type": "AWS::CloudWatch::Alarm",
 			"Condition": "DeleteOld",
 			"Properties": {
+				"AlarmDescription": "Failed to delete old snapshots from destination",
 				"ActionsEnabled": "true",
 				"ComparisonOperator": "GreaterThanOrEqualToThreshold",
 				"EvaluationPeriods": "2",
@@ -197,6 +214,20 @@
 				"Statistic": "Sum",
 				"Threshold": "2.0",
 				"AlarmActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraToolDest"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"OKActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraToolDest"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"InsufficientDataActions": [{
 					"Fn::If": ["SNSTopicIsEmpty", {
 						"Ref": "snsTopicSnapshotsAuroraToolDest"
 					}, {

--- a/cftemplates/snapshots_tool_aurora_source.json
+++ b/cftemplates/snapshots_tool_aurora_source.json
@@ -161,6 +161,7 @@
 		"alarmcwBackupsFailed": {
 			"Type": "AWS::CloudWatch::Alarm",
 			"Properties": {
+				"AlarmDescription": "DB backup status",
 				"ActionsEnabled": "true",
 				"ComparisonOperator": "GreaterThanOrEqualToThreshold",
 				"EvaluationPeriods": "1",
@@ -169,7 +170,22 @@
 				"Period": "300",
 				"Statistic": "Sum",
 				"Threshold": "1.0",
+				"TreatMissingData": "ignore",
 				"AlarmActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraTool"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"OKActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraTool"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"InsufficientDataActions": [{
 					"Fn::If": ["SNSTopicIsEmpty", {
 						"Ref": "snsTopicSnapshotsAuroraTool"
 					}, {
@@ -189,6 +205,7 @@
 			"Condition": "Share",
 			"Type": "AWS::CloudWatch::Alarm",
 			"Properties": {
+				"AlarmDescription": "DB backup transfer to DR region status",
 				"ActionsEnabled": "true",
 				"ComparisonOperator": "GreaterThanOrEqualToThreshold",
 				"EvaluationPeriods": "2",
@@ -198,6 +215,20 @@
 				"Statistic": "Sum",
 				"Threshold": "6.0",
 				"AlarmActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraTool"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"OKActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraTool"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"InsufficientDataActions": [{
 					"Fn::If": ["SNSTopicIsEmpty", {
 						"Ref": "snsTopicSnapshotsAuroraTool"
 					}, {
@@ -225,6 +256,20 @@
 				"Statistic": "Sum",
 				"Threshold": "2.0",
 				"AlarmActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraTool"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"OKActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraTool"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"InsufficientDataActions": [{
 					"Fn::If": ["SNSTopicIsEmpty", {
 						"Ref": "snsTopicSnapshotsAuroraTool"
 					}, {


### PR DESCRIPTION
When using the alarms for notifications it definitely helps to have a
brief regular language description to get an idea of what's happening.

Additionally, we want to receive notifications for when alarms clear as
well as when they alarm or insufficient data is available.

Finally, given we can set the cadence of the snapshots, we need the
alarms to ignore missing data points to avoid false alarms.