### PR TITLE
Remove redundant call to fetch tags.

### DIFF
--- a/lambda/snapshots_tool_utils.py
+++ b/lambda/snapshots_tool_utils.py
@@ -119,10 +119,6 @@ def get_own_snapshots_no_x_account(pattern, response, REGION):
     filtered = {}
     for snapshot in response['DBClusterSnapshots']:
 
-        client = boto3.client('rds', region_name=REGION)
-        response_tags = client.list_tags_for_resource(
-            ResourceName=snapshot['DBClusterSnapshotArn'])
-
         if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterSnapshotIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
             client = boto3.client('rds', region_name=REGION)
             response_tags = client.list_tags_for_resource(

--- a/lambda/snapshots_tool_utils.py
+++ b/lambda/snapshots_tool_utils.py
@@ -94,10 +94,6 @@ def get_own_snapshots_source(pattern, response):
     filtered = {}
     for snapshot in response['DBClusterSnapshots']:
 
-        client = boto3.client('rds', region_name=_REGION)
-        response_tags = client.list_tags_for_resource(
-            ResourceName=snapshot['DBClusterSnapshotArn'])
-
         if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterSnapshotIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
             client = boto3.client('rds', region_name=_REGION)
             response_tags = client.list_tags_for_resource(


### PR DESCRIPTION
This solves a problem where the function errors out after being throttled for too many ListTagsForResource calls.

Tags are fetched again in the if blocks so there's no need to fetch them at the top of this function. This also will skip tag fetches for snapshots that have been created automatically.