### PR TITLE
Pattern match against cluster not snapshot

### DIFF
--- a/lambda/snapshots_tool_utils.py
+++ b/lambda/snapshots_tool_utils.py
@@ -94,7 +94,7 @@ def get_own_snapshots_source(pattern, response):
     filtered = {}
     for snapshot in response['DBClusterSnapshots']:
 
-        if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterSnapshotIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
+        if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
             client = boto3.client('rds', region_name=_REGION)
             response_tags = client.list_tags_for_resource(
                 ResourceName=snapshot['DBClusterSnapshotArn'])
@@ -119,7 +119,7 @@ def get_own_snapshots_no_x_account(pattern, response, REGION):
     filtered = {}
     for snapshot in response['DBClusterSnapshots']:
 
-        if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterSnapshotIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
+        if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
             client = boto3.client('rds', region_name=REGION)
             response_tags = client.list_tags_for_resource(
                 ResourceName=snapshot['DBClusterSnapshotArn'])
@@ -143,7 +143,7 @@ def get_own_snapshots_share(pattern, response):
     # Filter manual snapshots by pattern. Returns a dict of snapshots with DBClusterSnapshotIdentifier as key and Status, DBClusterIdentifier as attributes
     filtered = {}
     for snapshot in response['DBClusterSnapshots']:
-        if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterSnapshotIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
+        if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
             filtered[snapshot['DBClusterSnapshotIdentifier']] = {
                 'Arn': snapshot['DBClusterSnapshotArn'], 'Status': snapshot['Status'], 'DBClusterIdentifier': snapshot['DBClusterIdentifier']}
         elif snapshot['SnapshotType'] == 'manual' and pattern == 'ALL_CLUSTERS' and snapshot['Engine'] in _SUPPORTED_ENGINES:
@@ -156,7 +156,7 @@ def get_shared_snapshots(pattern, response):
     # Returns a dict with only shared snapshots filtered by pattern, with DBSnapshotIdentifier as key and the response as attribute
     filtered = {}
     for snapshot in response['DBClusterSnapshots']:
-        if snapshot['SnapshotType'] == 'shared' and re.search(pattern, get_snapshot_identifier(snapshot)) and snapshot['Engine'] in _SUPPORTED_ENGINES:
+        if snapshot['SnapshotType'] == 'shared' and re.search(pattern, snapshot['DBClusterIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
             filtered[get_snapshot_identifier(snapshot)] = {
                 'Arn': snapshot['DBClusterSnapshotIdentifier'], 'StorageEncrypted': snapshot['StorageEncrypted'], 'DBClusterIdentifier': snapshot['DBClusterIdentifier']}
             if snapshot['StorageEncrypted'] is True:
@@ -177,7 +177,7 @@ def get_own_snapshots_dest(pattern, response):
     filtered = {}
     for snapshot in response['DBClusterSnapshots']:
 
-        if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterSnapshotIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
+        if snapshot['SnapshotType'] == 'manual' and re.search(pattern, snapshot['DBClusterIdentifier']) and snapshot['Engine'] in _SUPPORTED_ENGINES:
             filtered[snapshot['DBClusterSnapshotIdentifier']] = {
                 'Arn': snapshot['DBClusterSnapshotArn'], 'Status': snapshot['Status'], 'StorageEncrypted': snapshot['StorageEncrypted'], 'DBClusterIdentifier': snapshot['DBClusterIdentifier']}
 


### PR DESCRIPTION
*Issue #, if available:* #18 

*Description of changes:*

Updates re.search as appropriate to pattern match against DBClusterIdentifier instead of DBClusterSnapshotIdentifier to avoid orphaned snapshots as described in #18.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
