### PR TITLE
Only apply SNS topic policy if the topic is created by the stack

### DIFF
--- a/cftemplates/snapshots_tool_aurora_dest.json
+++ b/cftemplates/snapshots_tool_aurora_dest.json
@@ -138,6 +138,7 @@
 			}
 		},
 		"snspolicySnapshotsAuroraDest": {
+			"Condition": "SNSTopicIsEmpty",
 			"Type": "AWS::SNS::TopicPolicy",
 			"Properties": {
 				"Topics": [{

--- a/cftemplates/snapshots_tool_aurora_source.json
+++ b/cftemplates/snapshots_tool_aurora_source.json
@@ -138,6 +138,7 @@
 			}
 		},
 		"snspolicySnapshotsAurora": {
+			"Condition": "SNSTopicIsEmpty",
 			"Type": "AWS::SNS::TopicPolicy",
 			"Properties": {
 				"Topics": [{


### PR DESCRIPTION
If it is not created by the stack chances are there are specific topic policies applied to it already. This will override such existing policies. The topic can also exist in a different account/region where this will fail to create.
