### PR TITLE
Clarify KMS Parameter Description in Dest CFN

### DIFF
--- a/cftemplates/snapshots_tool_aurora_dest.json
+++ b/cftemplates/snapshots_tool_aurora_dest.json
@@ -33,12 +33,12 @@
 		"KmsKeyDestination": {
 			"Type": "String",
 			"Default": "None",
-			"Description": "Set to the ARN for the KMS key in the destination region to re-encrypt encrypted snapshots. Leave None if you are not using encryption"
+			"Description": "Set to the KMS Key Id in the destination region to re-encrypt encrypted snapshots. Leave None if you are not using encryption"
 		},
 		"KmsKeySource": {
 			"Type": "String",
 			"Default": "None",
-			"Description": "Set to the ARN for the KMS key in the SOURCE region to re-encrypt encrypted snapshots. Leave None if you are not using encryption"
+			"Description": "Set to the KMS Key Id in the SOURCE region to re-encrypt encrypted snapshots. Leave None if you are not using encryption"
 		},
 		"DeleteOldSnapshots": {
 			"Type": "String",


### PR DESCRIPTION
The boto `copy_db_cluster_snapshot` API takes KMS ID, not the KMS ARN. Updating the CFN parameter description to clarify the value that should be provided. 

Ref https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html#RDS.Client.copy_db_cluster_snapshot (KmsKeyId)