### PR TITLE
Add addTagsToResource permission

### DIFF
--- a/cftemplates/snapshots_tool_aurora_dest.json
+++ b/cftemplates/snapshots_tool_aurora_dest.json
@@ -306,7 +306,8 @@
 									"rds:ModifyDBClusterSnapshotAttribute",
 									"rds:CopyDBClusterSnapshot",
 									"rds:DescribeDBClusterSnapshotAttributes",
-									"rds:ListTagsForResource"
+									"rds:ListTagsForResource",
+									"rds:AddTagsToResource"
 								],
 								"Resource": [
 									"arn:aws:rds:*:*:cluster:*",

--- a/cftemplates/snapshots_tool_aurora_source.json
+++ b/cftemplates/snapshots_tool_aurora_source.json
@@ -351,7 +351,8 @@
 									"rds:DeleteDBClusterSnapshot",
 									"rds:ModifyDBClusterSnapshotAttribute",
 									"rds:DescribeDBClusterSnapshotAttributes",
-									"rds:ListTagsForResource"
+									"rds:ListTagsForResource",
+									"rds:AddTagsToResource"
 								],
 								"Resource": [{
 									"Fn::Join": [":", ["arn:aws:rds", {


### PR DESCRIPTION
fixes #34

*Issue #, if available:*
The takeSnapshot Lambda is failing because it tries to add a tag to the snapshot, but doesn't have sufficient permissions.

*Description of changes:*
Add "rds:AddTagsToResource" to the IAM policy created by the CF stack. Mirrors awslabs/rds-snapshot-tool#63

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
