### PR TITLE
Support default encrypted snapshots pr

### DIFF
--- a/cftemplates/snapshots_tool_aurora_source.json
+++ b/cftemplates/snapshots_tool_aurora_source.json
@@ -35,6 +35,11 @@
 			"Default": "7",
 			"Description": "Number of days to keep snapshots in retention before deleting them"
 		},
+		"KmsKeySource": {
+			"Type": "String",
+			"Default": "None",
+			"Description": "Set to the KMS Key Id in the SOURCE region if you need to re-encrypt default encrypted snapshots for cross-account sharing. Leave None otherwise."
+		},
 		"LogLevel": {
 			"Type": "String",
 			"Default": "ERROR",
@@ -179,6 +184,48 @@
 				}]
 			}
 		},
+		"alarmcwCopyFailed": {
+			"Type": "AWS::CloudWatch::Alarm",
+			"Properties": {
+				"AlarmDescription": "DB snapshot copying status",
+				"ActionsEnabled": "true",
+				"ComparisonOperator": "GreaterThanOrEqualToThreshold",
+				"EvaluationPeriods": "1",
+				"MetricName": "ExecutionsFailed",
+				"Namespace": "AWS/States",
+				"Period": "300",
+				"Statistic": "Sum",
+				"Threshold": "1.0",
+				"TreatMissingData": "ignore",
+				"AlarmActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraTool"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"OKActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraTool"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"InsufficientDataActions": [{
+					"Fn::If": ["SNSTopicIsEmpty", {
+						"Ref": "snsTopicSnapshotsAuroraTool"
+					}, {
+						"Ref": "SNSTopic"
+					}]
+				}],
+				"Dimensions": [{
+					"Name": "StateMachineArn",
+					"Value": {
+						"Ref": "statemachineCopySnapshotsAurora"
+					}
+				}]
+			}
+		},
 
 		"alarmcwShareFailed": {
 			"Condition": "Share",
@@ -292,6 +339,7 @@
 							{
 								"Effect": "Allow",
 								"Action": [
+									"rds:CopyDBClusterSnapshot",
 									"rds:CreateDBClusterSnapshot",
 									"rds:DeleteDBClusterSnapshot",
 									"rds:ModifyDBClusterSnapshotAttribute",
@@ -318,7 +366,14 @@
 										}, "*:cluster-snapshot:*"]]
 									}
 								]
-							}
+							},
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "kms:ListAliases"
+                                ],
+                                "Resource": "*"
+                            }
 						]
 					}
 
@@ -350,6 +405,9 @@
 						"REGION_OVERRIDE": {
 							"Ref": "SourceRegionOverride"
 						},
+						"SHARE_SNAPSHOTS": {
+							"Ref": "ShareSnapshots"
+						},
 						"SNAPSHOT_NAME_PREFIX": {
 							"Ref": "SnapshotNamePrefix"
 						}
@@ -366,6 +424,47 @@
 				"Timeout": 300
 			}
 		},
+		"lambdaCopySnapshotsAurora": {
+			"Type": "AWS::Lambda::Function",
+			"Properties": {
+				"Code": {
+					"S3Bucket": {
+								"Ref": "CodeBucket"
+					},
+					"S3Key": "copy_snapshots_source_aurora.zip"
+				},
+				"Description": "This Lambda function copies snapshots created by aurora_take_snapshot with the KMS key set in the environment variable KMS_KEY_SOURCE_REGION.",
+				"MemorySize": 512,
+				"Environment": {
+					"Variables": {
+					   "KMS_KEY_SOURCE_REGION": {
+							   "Ref": "KmsKeySource"
+					   },
+					   "PATTERN": {
+							   "Ref": "ClusterNamePattern"
+					   },
+					   "LOG_LEVEL": {
+							   "Ref": "LogLevel"
+					   },
+					   "REGION_OVERRIDE": {
+							   "Ref": "SourceRegionOverride"
+					   },
+					   "RETENTION_DAYS": {
+							   "Ref": "RetentionDays"
+					   }
+					}
+				},
+				"Role": {
+					"Fn::GetAtt": [
+						"iamroleSnapshotsAurora",
+						"Arn"
+					]
+				},
+				"Runtime": "python3.7",
+				"Handler": "lambda_function.lambda_handler",
+				"Timeout": 300
+		   }
+	   },
 		"lambdaShareSnapshotsAurora": {
 			"Type": "AWS::Lambda::Function",
 			"Condition": "Share",
@@ -470,10 +569,14 @@
 								}, {
 									"Fn::GetAtt": ["lambdaShareSnapshotsAurora", "Arn"]
 								}, {
+									"Fn::GetAtt": ["lambdaCopySnapshotsAurora", "Arn"]
+								}, {
 									"Fn::GetAtt": ["lambdaDeleteOldSnapshotsAurora", "Arn"]
 								}],
 									[{
 										"Fn::GetAtt": ["lambdaTakeSnapshotsAurora", "Arn"]
+									}, {
+										"Fn::GetAtt": ["lambdaCopySnapshotsAurora", "Arn"]
 									}, {
 										"Fn::GetAtt": ["lambdaDeleteOldSnapshotsAurora", "Arn"]
 									}]
@@ -533,6 +636,55 @@
 				}
 			}
 		},
+		"statemachineCopySnapshotsAurora": {
+			"Type": "AWS::StepFunctions::StateMachine",
+			"Properties": {
+				"DefinitionString": {
+					"Fn::Join": ["", [{
+						"Fn::Join": ["\n", [
+							" {\"Comment\":\"Copies default-key encrypted snapshots using a different key.\",",
+							" \"StartAt\":\"CopySnapshots\",",
+							" \"States\":{",
+							"   \"CopySnapshots\":{",
+							"     \"Type\":\"Task\",",
+							"     \"Resource\": "
+						]]
+					},
+						"\"",
+						{
+							"Fn::GetAtt": ["lambdaCopySnapshotsAurora", "Arn"]
+						}, "\"\n,",
+						{
+							"Fn::Join": ["\n", [
+								"     \"Retry\":[",
+								"       {",
+								"       \"ErrorEquals\":[ ",
+								"         \"SnapshotToolException\"",
+								"       ],",
+								"       \"IntervalSeconds\":300,",
+								"       \"MaxAttempts\":20,",
+								"       \"BackoffRate\":1",
+								"     },",
+								"     {",
+								"      \"ErrorEquals\":[ ",
+								"         \"States.ALL\"], ",
+								"         \"IntervalSeconds\": 30,",
+								"         \"MaxAttempts\": 20,",
+								"         \"BackoffRate\": 1",
+								"     }",
+								"    ],",
+								"    \"End\": true ",
+								"   }",
+								" }}"
+							]]
+						}
+					]]
+				},
+				"RoleArn": {
+					"Fn::GetAtt": ["iamroleStateExecution", "Arn"]
+				}
+		   }
+	   },
 		"statemachineShareSnapshotsAurora": {
 			"Type": "AWS::StepFunctions::StateMachine",
 			"Condition": "Share",
@@ -661,10 +813,14 @@
 								}, {
 									"Ref": "statemachineShareSnapshotsAurora"
 								}, {
+									"Ref": "statemachineCopySnapshotsAurora"
+								}, {
 									"Ref": "statemachineDeleteOldSnapshotsAurora"
 								}],
 									[{
 										"Ref": "stateMachineTakeSnapshotsAurora"
+									}, {
+										"Ref": "statemachineCopySnapshotsAurora"
 									}, {
 										"Ref": "statemachineDeleteOldSnapshotsAurora"
 									}]
@@ -716,6 +872,25 @@
 				}]
 			}
 		},
+        "cwEventCopySnapshotsAurora": {
+            "Type": "AWS::Events::Rule",
+            "Properties": {
+                "Description": "Triggers the CopySnapshotsAurora state machine",
+                "ScheduleExpression": {
+                    "Fn::Join": ["", ["cron(", "/30 * * * ? *", ")"]]
+                },
+                "State": "ENABLED",
+                "Targets": [{
+                    "Arn": {
+                        "Ref": "statemachineCopySnapshotsAurora"
+                    },
+                    "Id": "Target1",
+                    "RoleArn": {
+                        "Fn::GetAtt": ["iamroleStepInvocation", "Arn"]
+                    }
+                }]
+            }
+        },
 		"cwEventAuroraDeleteOldSnapshotsAurora": {
 			"Type": "AWS::Events::Rule",
 			"Condition": "DeleteOld",

--- a/lambda/Makefile
+++ b/lambda/Makefile
@@ -30,6 +30,7 @@ ZIPCMD=zip
 # if you define "._foo" as a file on this line, then it will zip up a
 # folder called foo, adding a standard file into it to make foo.zip.
 all:	._copy_snapshots_dest_aurora \
+	._copy_snapshots_source_aurora \
 	._copy_snapshots_no_x_account_aurora \
 	._delete_old_snapshots_dest_aurora \
 	._delete_old_snapshots_no_x_account_aurora \

--- a/lambda/copy_snapshots_source_aurora/lambda_function.py
+++ b/lambda/copy_snapshots_source_aurora/lambda_function.py
@@ -1,0 +1,103 @@
+'''
+Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+'''
+
+# copy_snapshots_source_aurora
+#
+# This Lambda function copies snapshots created by aurora_take_snapshot and re-encrypts them with the KMS key
+# set in the environment variable KMS_KEY_SOURCE_REGION.
+#
+# It will only copy snapshots tagged with both 'reEncrypt':'YES' and 'CreatedBy':'Snapshot Tool for Aurora'
+import boto3
+from datetime import datetime
+import os
+import logging
+from snapshots_tool_utils import *
+
+
+# Initialize from environment variable
+KMS_KEY_SOURCE_REGION = os.getenv('KMS_KEY_SOURCE_REGION', 'None').strip()
+LOGLEVEL = os.getenv('LOG_LEVEL', 'ERROR').strip()
+PATTERN = os.getenv('PATTERN', 'ALL_CLUSTERS')
+RETENTION_DAYS = int(os.getenv('RETENTION_DAYS'))
+
+if os.getenv('REGION_OVERRIDE', 'NO') != 'NO':
+    REGION = os.getenv('REGION_OVERRIDE').strip()
+else:
+    REGION = os.getenv('AWS_DEFAULT_REGION')
+
+
+logger = logging.getLogger()
+logger.setLevel(LOGLEVEL.upper())
+
+
+
+def lambda_handler(event, context):
+    pending_copies = 0
+    client = boto3.client('rds', region_name=REGION)
+    response = paginate_api_call(client, 'describe_db_cluster_snapshots', 'DBClusterSnapshots', SnapshotType='manual')
+    filtered = get_own_snapshots_source(PATTERN, response)
+
+    # Fetch all manual snapshots
+    for snapshot_identifier, snapshot_object in filtered.items():
+        snapshot_arn = snapshot_object['Arn']
+        response_tags = client.list_tags_for_resource(
+            ResourceName=snapshot_arn)
+    pending_copies = 0
+    client = boto3.client('rds', region_name=REGION)
+    response = paginate_api_call(client, 'describe_db_cluster_snapshots', 'DBClusterSnapshots', SnapshotType='manual')
+    filtered = get_own_snapshots_source(PATTERN, response)
+
+    # Find relevant snapshots
+    for snapshot_identifier, snapshot_object in filtered.items():
+        snapshot_arn = snapshot_object['Arn']
+        response_tags = client.list_tags_for_resource(
+            ResourceName=snapshot_arn)
+        if snapshot_object['Status'].lower() == 'available' and search_tag_reencrypt(response_tags):
+            # Check date
+            creation_date = get_timestamp(snapshot_identifier, filtered)
+            if creation_date:
+                time_difference = datetime.now() - creation_date
+                days_difference = time_difference.total_seconds() / 3600 / 24
+
+                # Only copy if it's newer than RETENTION_DAYS
+                if days_difference < RETENTION_DAYS:
+
+                    # Copy to own account
+                    try:
+                        copy_local(snapshot_identifier, snapshot_object)
+
+                    except Exception as e:
+                        pending_copies += 1
+                        logger.error(e)
+                        logger.error('Local copy pending: %s' % snapshot_identifier)
+                    else:
+                        client.add_tags_to_resource(
+                            ResourceName=snapshot_arn,
+                            Tags=[
+                                {
+                                    'Key': 'reEncrypt',
+                                    'Value': 'NO'
+                                },
+                            ]
+                        )
+                else:
+                    logger.info('Not copying %s locally. Older than %s days' % (snapshot_identifier, RETENTION_DAYS))
+
+            else:
+                logger.info('Not copying %s locally. No valid timestamp' % snapshot_identifier)
+
+    if pending_copies > 0:
+        log_message = 'Copies pending: %s. Needs retrying' % pending_copies
+        logger.error(log_message)
+        raise SnapshotToolException(log_message)
+
+
+if __name__ == '__main__':
+    lambda_handler(None, None)

--- a/lambda/copy_snapshots_source_aurora/lambda_function.py
+++ b/lambda/copy_snapshots_source_aurora/lambda_function.py
@@ -71,7 +71,7 @@ def lambda_handler(event, context):
 
                     # Copy to own account
                     try:
-                        copy_local(snapshot_identifier, snapshot_object)
+                        copy_local(snapshot_identifier, snapshot_object, f'{snapshot_identifier}-reencrypted')
 
                     except Exception as e:
                         pending_copies += 1

--- a/lambda/snapshots_tool_utils.py
+++ b/lambda/snapshots_tool_utils.py
@@ -207,6 +207,16 @@ def copy_local(snapshot_identifier, snapshot_object, target_identifier=None):
     tags = [{
             'Key': 'CopiedBy',
             'Value': 'Snapshot Tool for Aurora'
+            },
+            # CreatedBy so re-encrypted snapshots can be deleted automatically.
+            {
+            'Key': 'CreatedBy',
+            'Value': 'Snapshot Tool for Aurora'
+            },
+            # CreatedBy so re-encrypted snapshots can be shared and copied.
+            {
+            'Key': 'shareAndCopy',
+            'Value': 'YES'
             }]
 
     if snapshot_object['StorageEncrypted']:
@@ -346,7 +356,8 @@ def paginate_api_call(client, api_call, objecttype, *args, **kwargs):
 
 
 def search_tag_share(response):
-    # Takes a describe_db_cluster_snapshots response and searches for our shareAndCopy tag
+    # Takes a describe_db_cluster_snapshots response and searches for our shareAndCopy tag,
+    # indicating that the snapshot can be shared.
     try:
 
         for tag in response['TagList']:
@@ -399,3 +410,10 @@ def search_tag_copied(response):
 
     return False
 
+# lookup_kms_aliases() takes an arn and returns its aliases.
+def lookup_kms_aliases(key_arn):
+    client = boto3.client('kms')
+    response = client.list_aliases(
+        KeyId=key_arn
+    )
+    return [a['AliasName'] for a in response['Aliases']]

--- a/lambda/snapshots_tool_utils.py
+++ b/lambda/snapshots_tool_utils.py
@@ -359,6 +359,27 @@ def search_tag_share(response):
 
     return False
 
+# search_tag_reencrypt() takes a describe_db_cluster_snapshots() response and
+# searches for a reEncrypt tag, indicating that the snapshot needs to be
+# re-encrypted with a customer-managed key before it can be shared.
+def search_tag_reencrypt(response):
+    try:
+
+        for tag in response['TagList']:
+
+            if tag['Key'] == 'reEncrypt' and tag['Value'] == 'YES':
+
+                for tag2 in response['TagList']:
+
+                    if tag2['Key'] == 'CreatedBy' and tag2['Value'] == 'Snapshot Tool for Aurora':
+
+                        return True
+
+    except Exception:
+        return False
+
+    return False
+
 
 def search_tag_copied(response):
     try:

--- a/lambda/snapshots_tool_utils.py
+++ b/lambda/snapshots_tool_utils.py
@@ -102,6 +102,8 @@ def get_own_snapshots_source(pattern, response):
             if search_tag_created(response_tags):
                 filtered[snapshot['DBClusterSnapshotIdentifier']] = {
                     'Arn': snapshot['DBClusterSnapshotArn'], 'Status': snapshot['Status'], 'DBClusterIdentifier': snapshot['DBClusterIdentifier']}
+                if snapshot['StorageEncrypted']:
+                    filtered[snapshot['DBClusterSnapshotIdentifier']]['StorageEncrypted'] = True
         #Changed the next line to search for ALL_CLUSTERS or ALL_SNAPSHOTS so it will work with no-x-account
         elif snapshot['SnapshotType'] == 'manual' and (pattern == 'ALL_CLUSTERS' or pattern == 'ALL_SNAPSHOTS') and snapshot['Engine'] in _SUPPORTED_ENGINES:
             client = boto3.client('rds', region_name=_REGION)
@@ -111,6 +113,8 @@ def get_own_snapshots_source(pattern, response):
             if search_tag_created(response_tags):
                 filtered[snapshot['DBClusterSnapshotIdentifier']] = {
                     'Arn': snapshot['DBClusterSnapshotArn'], 'Status': snapshot['Status'], 'DBClusterIdentifier': snapshot['DBClusterIdentifier']}
+                if snapshot['StorageEncrypted']:
+                    filtered[snapshot['DBClusterSnapshotIdentifier']]['StorageEncrypted'] = True
 
     return filtered
 

--- a/lambda/take_snapshots_aurora/lambda_function.py
+++ b/lambda/take_snapshots_aurora/lambda_function.py
@@ -23,6 +23,7 @@ from snapshots_tool_utils import *
 LOGLEVEL = os.getenv('LOG_LEVEL').strip()
 BACKUP_INTERVAL = int(os.getenv('INTERVAL', '24'))
 PATTERN = os.getenv('PATTERN', 'ALL_CLUSTERS')
+SHARE_SNAPSHOTS = os.getenv('SHARE_SNAPSHOTS', 'NONE')
 SNAPSHOT_NAME_PREFIX = os.getenv('SNAPSHOT_NAME_PREFIX', 'NONE')
 
 if os.getenv('REGION_OVERRIDE', 'NO') != 'NO':
@@ -71,12 +72,24 @@ def lambda_handler(event, context):
                 snapshot_identifier = '%s-%s' % (
                     db_cluster['DBClusterIdentifier'], timestamp_format)
 
+            # What to do with the snapshot after taking it.
+            # If no encryption or non-default encryption, it's ready for sharing and copying.
+            # So default to that.
+            tag_key = 'shareAndCopy'
+            # Then find out if the snapshot's encrypted.
+            if db_cluster.get('KmsKeyId'):
+                # If so, with what KMS key?
+                kms_aliases = lookup_kms_aliases(db_cluster['KmsKeyId'])
+                # If we need to share a snapshot encrypted with the default key,
+                # the snapshot will need to be re-encrypted first. So override the default tag.
+                if SHARE_SNAPSHOTS == 'TRUE' and 'alias/aws/rds' in kms_aliases:
+                    tag_key = 'reEncrypt'
             try:
                 response = client.create_db_cluster_snapshot(
                     DBClusterSnapshotIdentifier=snapshot_identifier,
                     DBClusterIdentifier=db_cluster['DBClusterIdentifier'],
                     Tags=[{'Key': 'CreatedBy', 'Value': 'Snapshot Tool for Aurora'}, {
-                        'Key': 'CreatedOn', 'Value': timestamp_format}, {'Key': 'shareAndCopy', 'Value': 'YES'}]
+                        'Key': 'CreatedOn', 'Value': timestamp_format}, {'Key': tag_key, 'Value': 'YES'}]
                 )
             except Exception as e:
                 logger.error(e)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aurora-snapshot-tool/issues/36

*Description of changes:*
The use case here is to enable backing up of snapshots encrypted with the default key. Those can't be shared directly.

This PR creates a new lambda to copy snapshots that are encrypted with a default key, using a different, customer-managed key. Those snapshots can then be shared.

The new lambda comes with additional resources provisioned in the CloudFormation template, such as the corresponding state machine to execute the lambda.

A new parameter is added to allow the user to supply the key when creating the CloudFormation stack.

Some changes are made to the existing logic to support the new use case, especially around tagging.

*Tests:*
I've tested the following scenarios:

1. From us-east-1 in one account to us-east-2 in another account.
2. From us-east-1 to us-east-2 in the same account.

*Notes:*

* This PR differs from [this open PR](https://github.com/awslabs/aurora-snapshot-tool/pull/27) by creating an entirely separate lambda to do the copying, instead of adding logic to copy in the snapshot-sharing lambda. It makes the PR complex, but I chose this approach for two reasons:

   1) It conforms to the modular structure of the project, where each lambda performs a separate step.
   2) It allows the function to run asynchronously and complete successfully even when copying the snapshot takes longer than the max run time of a lambda.

* Unlike the other PR, it hard-codes the alias name for the current default KMS key, rather than querying for AWS-owned keys. This is mostly because I didn't think of that, and I would be open to changing it.

* The snapshots in the destination region will now have the `shareAndCopy` tag, even though they aren't meant to be shared and copied. I believe this is harmless, but it's obviously not ideal. I would like to change that, but I wanted to get a working iteration of the code out there for review before laboring to perfect it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.