### PR TITLE
cwEventCopySnapshotsAurora: apply valid cron schedule

### DIFF
--- a/cftemplates/snapshots_tool_aurora_dest.json
+++ b/cftemplates/snapshots_tool_aurora_dest.json
@@ -582,7 +582,7 @@
 			"Properties": {
 				"Description": "Triggers the Aurora DeleteOld state machine in the destination account",
 				"ScheduleExpression": {
-					"Fn::Join": ["", ["cron(", "0 /1 * * ? *", ")"]]
+					"Fn::Join": ["", ["cron(", "0 */1 * * ? *", ")"]]
 				},
 				"State": "ENABLED",
 				"Targets": [{

--- a/cftemplates/snapshots_tool_aurora_dest.json
+++ b/cftemplates/snapshots_tool_aurora_dest.json
@@ -562,7 +562,7 @@
 			"Properties": {
 				"Description": "Triggers the Aurora Copy state machine in the destination account",
 				"ScheduleExpression": {
-					"Fn::Join": ["", ["cron(", "/30 * * * ? *", ")"]]
+					"Fn::Join": ["", ["cron(", "*/30 * * * ? *", ")"]]
 				},
 				"State": "ENABLED",
 				"Targets": [{


### PR DESCRIPTION
*Issue #, if available:*

After applying the destination template to the account, the following scheduling error is observable in the `cwEventCopySnapshotsAurora` events configuration:

![image](https://user-images.githubusercontent.com/991850/222508475-a26e073c-5f96-481b-a3d3-e8870d6255c4.png)

The same is observed with the cwEventDeleteOldSnapshotsAurora event:

![image](https://user-images.githubusercontent.com/991850/222514319-24c6a744-8818-45f9-b4bf-bc55f81a8297.png)


*Description of changes:*

- Add missing `*` to cron expression resulting in the copySnapshot lambda running on the expected 30 minute interval
- Add missing * character causing the cwEventDeleteOldSnapshotsAurora cron expression to run on the expected 1 hour interval


 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
